### PR TITLE
generic datamodel for chillhub+devices

### DIFF
--- a/example/example_data_beer_inventory.json
+++ b/example/example_data_beer_inventory.json
@@ -1,79 +1,105 @@
 {
   "containers" : {
+    "-3ucs1aya03" : {
+      "containerType" : "milkminder_container", // change key from compType to containerType
+      "name" : "My MilkMinder",
+      "objects" :{
+        "-J_M7uoN2pjqP8I7LD3T" : "milkminder" //changed value from true to the object Type
+      }
+    },
     "-JUApWC5RZF-LgQmoUxd" : {
-      "children" : {
-        "-JUApygMzgusoiSlvV-0" : true
+      "containers" : { //modified this key from children to containers
+        "-JUApygMzgusoiSlvV-0" : "refrigerator" //the key is the container reference and the value is the containerType. So here, we can decipher that this has a refrigerator "device"
       },
+      "containerType" : "orgRootContainer", // change key from compType to containerType
       "description" : "root container",
-      "name" : "simplelogin:18_root",
-      "owner" : "simplelogin:18",
+      "name" : "simplelogin:1_root",
+      "owner" : "simplelogin:1",
       "parent" : false
     },
     "-JUApWC5RZF-LgQmoUxe" : {
-      "description" : "root container",
-      "name" : "simplelogin:19_root",
-      "owner" : "simplelogin:19",
-      "parent" : false,
-      "children" : {
-        "-JUApygMzgusoiSlvV-1" : true
+      "containers" : { //modified this key from children to containers
+        "-JUApygMzgusoiSlvV-1" : "consumedList" //the key is the container reference and the value is the containerType. So here, we can decipher that this has a consumerList
       },
+      "containerType" : "userRootContainer", // change key from compType to containerType
+      "description" : "root container",
+      "name" : "simplelogin:2_root",
       "organizations" : {
-       "-JUApWC5RZF-LgQmoUxd" : true
-      }
+        "-JUApWC5RZF-LgQmoUxd" : "orgRootContainer" //the key is the container reference and the value is the containerType. So here, we can decipher that this is a member of an organization
+      },
+      "owner" : "simplelogin:2",
+      "parent" : false
     },
     "-JUApygMzgusoiSlvV-0" : {
+      "containerType" : "refrigerator", // change key from compType to containerType
       "description" : "Refrigerator container",
-      "compType" : "refrigerator",
       "name" : "Refrigerator",
-      "owner" : "simplelogin:18",
-      "parent" : "-JUApWC5RZF-LgQmoUxd",
-      "objects" : {
-        "spot1" : "-JUAwerASDvas-1g12j",
-        "spot2" : "-JUG7T_C4iVFZMMPjCB0"
-      }
+      "containers" : { //changed from objects to containers, since it references sub containers
+        "-he6ke7hocc" : "beerminder_container", //the key is the container reference and the value is the containerType. So here, we can decipher that this has a beerminder "device"
+        "-3ucs1aya03" : "milkminder_container" //the key is the container reference and the value is the containerType. So here, we can decipher that this has a milkminder "device"
+      },
+      "owner" : "simplelogin:1",
+      "parent" : "-JUApWC5RZF-LgQmoUxd"
     },
     "-JUApygMzgusoiSlvV-1" : {
+      "containerType" : "consumedList", // change key from compType to containerType
       "description" : "User1 Consumed Container",
-      "compType" : "consumedList",
       "name" : "User1 Consumed Container",
-      "owner" : "simplelogin:19",
-      "parent" : "-JUApWC5RZF-LgQmoUxe",
+      "owner" : "simplelogin:2",
+      "parent" : "-JUApWC5RZF-LgQmoUxe"
+    },
+    "-he6ke7hocc" : {
+      "containerType" : "beerminder_container", // change key from compType to containerType
+      "name" : "Beerminder_firstbuild",
       "objects" : {
-      }
+        "-JUAwerASDvas-1g12j" : "beer", //changed value from true to the object Type
+        "-JUG7T_C4iVFZMMPjCB0" : "beer" //changed value from true to the object Type
+      },
+      "parent" : "-JUApygMzgusoiSlvV-0"
     }
   },
   "objects" : {
     "-JUAwerASDvas-1g12j" : {
-      "created_at" : 1414444662,
-      "updated_at" : null,
-      "container" : "-JUApygMzgusoiSlvV-0",
       "consumed" : false,
       "consumer" : "",
-      "data" : "Westvleteren 12"
+      "container" : "-he6ke7hocc",
+      "data" : "Bud Light",
+      "type" : "beer"
     },
     "-JUG7T_C4iVFZMMPjCB0" : {
-      "created_at" : 1414444662,
-      "updated_at" : null,
+      "consumed" : true,
+      "consumer" : "simplelogin:2",
+      "container" : "-he6ke7hocc",
+      "data" : "Magic Hat",
+      "type" : "beer"
+    },
+    "-J_M7uoN2pjqP8I7LD3T" : {
       "container" : "-JUApygMzgusoiSlvV-0",
-      "consumed" : false,
-      "consumer" : "",
-      "data" : "Founders Kentucky Breakfast Stout"
+      "name" : "MilkMinder",
+      "type" : "milkminder",
+      "weight" : 15
     }
   },
+  "schemas" : {
+    "beerminder" : "status,count",
+    "milkscale" : "status,weight"
+  },
   "users" : {
-    "simplelogin:18" : {
+    "simplelogin:1" : {
       "displayName" : "Organization User",
       "email" : "org@example.com",
       "provider" : "password",
-      "provider_id" : "18",
-      "rootContainer" : "-JUApWC5RZF-LgQmoUxd"
+      "provider_id" : "1",
+      "rootContainer" : "-JUApWC5RZF-LgQmoUxd",
+      "userType":"organization"
     },
-    "simplelogin:19" : {
+    "simplelogin:2" : {
       "displayName" : "User1",
       "email" : "user1@example.com",
       "provider" : "password",
-      "provider_id" : "19",
-      "rootContainer" : "-JUApWC5RZF-LgQmoUxe"
+      "provider_id" : "2",
+      "rootContainer" : "-JUApWC5RZF-LgQmoUxe",
+      "userType":"member"
     }
   }
 }

--- a/example/example_data_chillhub_generic.json
+++ b/example/example_data_chillhub_generic.json
@@ -56,8 +56,10 @@
       "compType" : "beerminder_container",
       "name" : "Beerminder_firstbuild",
       "objects" : {
-        "-JUAwerASDvas-1g12j" : true,
-        "-JUG7T_C4iVFZMMPjCB0" : true
+        "beer":{
+          "-JUAwerASDvas-1g12j" : true,
+          "-JUG7T_C4iVFZMMPjCB0" : true
+        }
       },
       "parent" : "-JUApygMzgusoiSlvV-0"
     }

--- a/example/example_data_chillhub_generic.json
+++ b/example/example_data_chillhub_generic.json
@@ -1,0 +1,107 @@
+{
+  "containers" : {
+    "-3ucs1aya03" : {
+      "compType" : "milkminder_container",
+      "name" : "My MilkMinder",
+      "objects" : {
+        "-J_M7uoN2pjqP8I7LD3T" : true
+      }
+    },
+    "-JUApWC5RZF-LgQmoUxd" : {
+      "children" : {
+        "-JUApygMzgusoiSlvV-0" : true
+      },
+      "compType" : "orgRootContainer",
+      "description" : "root container",
+      "name" : "simplelogin:1_root",
+      "owner" : "simplelogin:1",
+      "parent" : false
+    },
+    "-JUApWC5RZF-LgQmoUxe" : {
+      "children" : {
+        "-JUApygMzgusoiSlvV-1" : true
+      },
+      "compType" : "userRootContainer",
+      "description" : "root container",
+      "name" : "simplelogin:2_root",
+      "organizations" : {
+        "-JUApWC5RZF-LgQmoUxd" : true
+      },
+      "owner" : "simplelogin:2",
+      "parent" : false
+    },
+    "-JUApygMzgusoiSlvV-0" : {
+      "compType" : "refrigerator",
+      "description" : "Refrigerator container",
+      "name" : "Refrigerator",
+      "objects" : {
+        "beerminder" : {
+          "-he6ke7hocc" : true
+        },
+        "milkminder" : {
+          "-3ucs1aya03" : true
+        }
+      },
+      "owner" : "simplelogin:1",
+      "parent" : "-JUApWC5RZF-LgQmoUxd"
+    },
+    "-JUApygMzgusoiSlvV-1" : {
+      "compType" : "consumedList",
+      "description" : "User1 Consumed Container",
+      "name" : "User1 Consumed Container",
+      "owner" : "simplelogin:2",
+      "parent" : "-JUApWC5RZF-LgQmoUxe"
+    },
+    "-he6ke7hocc" : {
+      "compType" : "beerminder_container",
+      "name" : "Beerminder_firstbuild",
+      "objects" : {
+        "-JUAwerASDvas-1g12j" : true,
+        "-JUG7T_C4iVFZMMPjCB0" : true
+      },
+      "parent" : "-JUApygMzgusoiSlvV-0"
+    }
+  },
+  "objects" : {
+    "-JUAwerASDvas-1g12j" : {
+      "consumed" : false,
+      "consumer" : "",
+      "container" : "-he6ke7hocc",
+      "data" : "Bud Light",
+      "type" : "beer"
+    },
+    "-JUG7T_C4iVFZMMPjCB0" : {
+      "consumed" : true,
+      "consumer" : "simplelogin:2",
+      "container" : "-he6ke7hocc",
+      "data" : "Magic Hat",
+      "type" : "beer"
+    },
+    "-J_M7uoN2pjqP8I7LD3T" : {
+      "container" : "-JUApygMzgusoiSlvV-0",
+      "name" : "MilkMinder",
+      "type" : "milkminder",
+      "weight" : 15
+    }
+  },
+  "schemas" : {
+    "beerminder" : "status,count",
+    "milkscale" : "status,weight"
+  },
+  "users" : {
+    "simplelogin:1" : {
+      "displayName" : "Organization User",
+      "email" : "org@example.com",
+      "provider" : "password",
+      "provider_id" : "1",
+      "rootContainer" : "-JUApWC5RZF-LgQmoUxd"
+    },
+    "simplelogin:2" : {
+      "displayName" : "User1",
+      "email" : "user1@example.com",
+      "provider" : "password",
+      "provider_id" : "2",
+      "rootContainer" : "-JUApWC5RZF-LgQmoUxe"
+    }
+  }
+}

--- a/example/example_data_chillhub_generic.json
+++ b/example/example_data_chillhub_generic.json
@@ -3,8 +3,10 @@
     "-3ucs1aya03" : {
       "compType" : "milkminder_container",
       "name" : "My MilkMinder",
-      "objects" : {
-        "-J_M7uoN2pjqP8I7LD3T" : true
+      "objects" :{ 
+        "milkminder":{
+          "-J_M7uoN2pjqP8I7LD3T" : true
+        }
       }
     },
     "-JUApWC5RZF-LgQmoUxd" : {

--- a/example/schema_chillhub.json
+++ b/example/schema_chillhub.json
@@ -1,0 +1,43 @@
+{
+    containers:{
+        $container:{
+            description: String,
+            name: String,
+            owner: String,              // SimpleLogin username that owns the container
+            parent: String,             // ID of parent container
+            compType: String,           // Type of container 
+            children:{                  // Array of containers children of this 
+                $containerId: true
+            },
+            organizations:{             // The organization it belongs to
+                $containerId: true
+            },
+            objects:{                   // All the objects (devices) connect to this container
+                $objectType: objectId   // "beerMinder":"myObjectID"
+            }
+        }
+    },
+    objects:{
+        $object:{
+            consumed: Boolean,           // Status if the object was consumed
+            consumer: String,            // SimpleLogin Id of the consumer
+            name: String,                // Name of the object
+            compType: String,            // Type of object
+            container: String,           // ContainerId of where the object is registered
+            //Other values could be added depending on the object type
+        }
+    }
+    schemas:{
+        $objectType: String,             // List of values monitored for an objectType (beerminder, milkminder)
+    },
+    users:{
+        $user:{
+            displayName:String,          // User's fullname
+            email: String,               // User's email
+            provider: String,            // Provider (facebook,google, password,...)
+            provider_id: String,         // Provider's ID
+            rootContainer: String,       // Container of type Root for the corresponsing user
+            userType: String             // User's type (Organization, Member,...)
+        }
+    }
+}

--- a/example/schema_chillhub.json
+++ b/example/schema_chillhub.json
@@ -3,30 +3,30 @@
         $container:{
             description: String,
             name: String,
-            owner: String,              // SimpleLogin username that owns the container
-            parent: String,             // ID of parent container
-            compType: String,           // Type of container 
-            children:{                  // Array of containers children of this 
-                $containerId: true
+            owner: String,                       // SimpleLogin username that owns the container
+            parent: String,                      // ID of parent container
+            containerType: String,               // Type of container
+            containers:{                         // Array of containers children of this
+                $containerId: $containerType     // $containerType is equal to the containerType of the container we are referencing
             },
-            organizations:{             // The organization it belongs to
-                $containerId: true
+            organizations:{                      // The organization it belongs to
+                $containerId: $containerType
             },
-            objects:{                   // All the objects (devices) connect to this container
-                $objectType: objectId   // "beerMinder":"myObjectID"
+            objects:{                            // All the objects (devices) connect to this container
+                $objectId: $objectType           // "SDFkja304-v":"beer"
             }
         }
     },
     objects:{
         $object:{
-            consumed: Boolean,           // Status if the object was consumed
-            consumer: String,            // SimpleLogin Id of the consumer
-            name: String,                // Name of the object
-            compType: String,            // Type of object
-            container: String,           // ContainerId of where the object is registered
+            consumed: Boolean,                   // Status if the object was consumed
+            consumer: String,                    // SimpleLogin Id of the consumer
+            name: String,                        // Name of the object
+            type: String,                        // Type of object
+            container: String,                   // ContainerId of where the object is registered
             //Other values could be added depending on the object type
         }
-    }
+    },
     schemas:{
         $objectType: String,             // List of values monitored for an objectType (beerminder, milkminder)
     },


### PR DESCRIPTION
A way to represent a datamodel on Firebase.

Inspired by what found in Firebase Datasets: https://www.firebase.com/docs/open-data/transit.html#section-data-structure

This datamodel is supposed to be generic and should work for chillhub and any connected devices.

main changes:
- a fridge container will list in `objects`, the different devices connected to it.

Those devices could be containers or objects.
For example, In the case of a beerminder, it should be a container with an array of objects to beers.
- containers should have `compType` to defined which type of container they are
